### PR TITLE
Update lint rules to be more friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
         'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
     ],
     rules: {
-        'react/prop-types': 0,
+        'react/prop-types': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         'prettier/prettier': ['error'],
@@ -18,11 +18,11 @@ module.exports = {
         'no-use-before-define': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         'react/no-unescaped-entities': 'off',
-        'react-hooks/exhaustive-deps': 'off',
+        'react-hooks/exhaustive-deps': 'warn',
         '@typescript-eslint/no-non-null-assertion': 'off',
         'react/display-name': 'off',
-        'react/display-name': 'off',
-        '@typescript-eslint/no-empty-function': 'off'
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-inferrable-types': 'off'
     },
     ignorePatterns: ['dist/**/*.js'],
     parserOptions: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/ts-linting-configs",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- disabled `@typescript-eslint/no-inferrable-types`. I believe this rule is actively harmful. we should be allowed to explicitly specify types that we expect so that TS can tell us when we're wrong.
- changed `react-hooks/exhaustive-deps` to be a warning. This should allow us to start fixing places where we should be passing deps so we can eventually enable this rule